### PR TITLE
Fix ARM Neon compilation and MulAdd implementation

### DIFF
--- a/include/FastSIMD/ToolSet/ARM/128/f32x4.h
+++ b/include/FastSIMD/ToolSet/ARM/128/f32x4.h
@@ -232,12 +232,12 @@ namespace FS
     template<FastSIMD::FeatureSet SIMD, typename = EnableIfNative<f32<4, SIMD>>, typename = std::enable_if_t<SIMD & FastSIMD::FeatureFlag::FMA>>
     FS_FORCEINLINE f32<4, SIMD> FMulAdd( const f32<4, SIMD>& a, const f32<4, SIMD>& b, const f32<4, SIMD>& c )
     {
-        return vmlaq_f32( b.native, c.native, a.native );
+        return vmlaq_f32( c.native, b.native, a.native );
     }
 
     template<FastSIMD::FeatureSet SIMD, typename = EnableIfNative<f32<4, SIMD>>, typename = std::enable_if_t<SIMD & FastSIMD::FeatureFlag::FMA>>
     FS_FORCEINLINE f32<4, SIMD> FNMulAdd( const f32<4, SIMD>& a, const f32<4, SIMD>& b, const f32<4, SIMD>& c )
     {
-        return vmlaq_f32( b.native, c.native, a.native );
+        return vmlsq_f32( c.native, b.native, a.native );
     }
 }

--- a/include/FastSIMD/ToolSet/ARM/128/m32x4.h
+++ b/include/FastSIMD/ToolSet/ARM/128/m32x4.h
@@ -17,8 +17,7 @@ namespace FS
 
         FS_FORCEINLINE Register() = default;
 
-        template<typename T = NativeType>
-        FS_FORCEINLINE Register( std::enable_if_t<OPTIMISE_FLOAT, T> v ) : native( v ) { }
+        FS_FORCEINLINE Register( NativeType v ) : native( v ) { }
 
         template<typename T = Register<Mask<32, false>, 4, SIMD>>
         FS_FORCEINLINE Register( const std::enable_if_t<OPTIMISE_FLOAT, T>& v ) : native( v.native ) { }


### PR DESCRIPTION
This fixes an incorrect implementation for FMA on NEON.

I also had issues compiling the library due to the the enable_if constraint on NEON f32 register constructor. Looking at the other implementations, they don't have the enable_if, but I wasn't entirely sure what it's purpose was.

Here's a before an after for comparison:
<img width="1552" alt="image" src="https://github.com/Auburn/FastSIMD/assets/755798/1d0c5cae-5a2d-4988-bbb8-d9bc1872f577">
<img width="1552" alt="image" src="https://github.com/Auburn/FastSIMD/assets/755798/eb8e2f9c-c421-4194-bd6e-7dc34d8edfc3">
