### PR TITLE
ARM NEON f32x4: fix FMulAdd/FNMulAdd operand order

### DIFF
--- a/include/FastSIMD/ToolSet/ARM/128/f32x4.h
+++ b/include/FastSIMD/ToolSet/ARM/128/f32x4.h
@@ -244,12 +244,12 @@ namespace FS
     template<FastSIMD::FeatureSet SIMD, typename = EnableIfNative<f32<4, SIMD>>, typename = EnableIfRelaxed<SIMD>>
     FS_FORCEINLINE f32<4, SIMD> FMulAdd( const f32<4, SIMD>& a, const f32<4, SIMD>& b, const f32<4, SIMD>& c )
     {
-        return vmlaq_f32( b.native, c.native, a.native );
+        return vmlaq_f32( c.native, a.native, b.native );
     }
 
     template<FastSIMD::FeatureSet SIMD, typename = EnableIfNative<f32<4, SIMD>>, typename = EnableIfRelaxed<SIMD>>
     FS_FORCEINLINE f32<4, SIMD> FNMulAdd( const f32<4, SIMD>& a, const f32<4, SIMD>& b, const f32<4, SIMD>& c )
     {
-        return vmlaq_f32( b.native, c.native, a.native );
+        return vmlsq_f32( c.native, a.native, b.native );
     }
 }


### PR DESCRIPTION
- FMulAdd must compute c + ab; FNMulAdd must compute c - ab.
- Corrects NEON/AARCH64 vs scalar mismatches observed in FastNoise2 consistency tests.
- Minimal change: 2 insertions, 2 deletions in ToolSet/ARM/128/f32x4.h.

Posting this in case it will be faster to merge then https://github.com/Auburn/FastSIMD/pull/3
